### PR TITLE
Use new puppet-lint gem

### DIFF
--- a/puppet-lint-file_ensure-check.gemspec
+++ b/puppet-lint-file_ensure-check.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7.0'
 
-  spec.add_dependency 'puppet-lint', '>= 3', '< 5'
+  spec.add_dependency 'puppetlabs-puppet-lint', '~> 5.0'
   spec.add_development_dependency 'mime-types', '~> 3.4', '>= 3.4.1'
 end


### PR DESCRIPTION
Using the now-maintained puppetlabs-puppet-lint over puppet-lint